### PR TITLE
Fix several bugs with result iteration and image loading

### DIFF
--- a/test/ocr-client-test.js
+++ b/test/ocr-client-test.js
@@ -28,11 +28,11 @@ describe("OCRClient", () => {
   it("extracts bounding boxes from image", async function () {
     this.timeout(2_000);
 
-    const imageData = await loadImage(resolve("./test-page.jpg"));
+    const imageData = await loadImage(resolve("./small-test-page.jpg"));
     await ocr.loadImage(imageData);
 
     const boxes = await ocr.getBoundingBoxes("word");
-    assert.isTrue(boxes.length >= 640 && boxes.length < 650);
+    assert.equal(boxes.length, 159);
     for (let box of boxes) {
       assert.isNumber(box.left);
       assert.isNumber(box.right);


### PR DESCRIPTION
 - Visit the first word/line of the results. Unlike most iteration APIs,
   the iterator that Tesseract returns is already positioned at the
   first word/line and should not be advanced before returning the first
   result. The `GetIterator` method can however return a null pointer,
   so handle that.

 - Extract the full text for whatever unit (word, line, paragraph) is
   being iterated over, not just the first word in that unit

 - Add a note about why `getBoundingBoxes` and `getTextBoxes` can return
   different numbers of words

 - Add checks for zero width/height images, as this doesn't cause an
   error from Tesseract itself (sigh)

 - Add tests for results of processing an empty image