### PR TITLE
Support running layout analysis without a model loaded

### DIFF
--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -86,16 +86,20 @@ class OCREngine {
       return OCRResult("Failed to load training data");
     }
 
-    // Enable page segmentation and layout analysis. Must be called after `Init`
-    // to take effect. Without this Tesseract defaults to treating the whole
-    // page as one block of text.
-    tesseract_->SetPageSegMode(tesseract::PSM_AUTO);
-
     return {};
   }
 
   OCRResult LoadImage(const std::string& image_data, int width, int height,
                       int bytes_per_pixel, int bytes_per_line) {
+    // Initialize for layout analysis only if a model has not been loaded.
+    // This is a no-op if a model has been loaded.
+    tesseract_->InitForAnalysePage();
+
+    // Enable page segmentation and layout analysis. Must be called after `Init`
+    // to take effect. Without this Tesseract defaults to treating the whole
+    // page as one block of text.
+    tesseract_->SetPageSegMode(tesseract::PSM_AUTO);
+
     auto min_buffer_len = height * bytes_per_line;
     if (image_data.size() < min_buffer_len) {
       return OCRResult("Image buffer length does not match width/height");

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -122,10 +122,6 @@ export class OCREngine {
    * @param {ImageBitmap|ImageData} image
    */
   loadImage(image) {
-    if (!this._modelLoaded) {
-      throw new Error("Model must be loaded before image");
-    }
-
     let imageData;
     if (typeof ImageBitmap !== "undefined" && image instanceof ImageBitmap) {
       imageData = imageDataFromBitmap(image);
@@ -154,7 +150,8 @@ export class OCREngine {
    *
    * This operation is relatively cheap compared to text recognition, so can
    * provide much faster results if only the location of lines/words etc. on
-   * the page is required, not the text content.
+   * the page is required, not the text content. This operation can also be
+   * performed before a text recognition model is loaded.
    *
    * This method may return a different number/positions of words on a line
    * compared to {@link getTextBoxes} due to the simpler analysis. After full
@@ -175,11 +172,16 @@ export class OCREngine {
    * not already done, and return bounding boxes and text content for a given
    * unit of text.
    *
+   * A text recognition model must be loaded with {@link loadModel} before this
+   * is called.
+   *
    * @param {TextUnit} unit
    * @return {TextItem[]}
    */
   getTextBoxes(unit) {
     this._checkImageLoaded();
+    this._checkModelLoaded();
+
     const textUnit = this._textUnitForUnit(unit);
     return jsArrayFromStdVector(this._engine.getTextBoxes(textUnit));
   }
@@ -188,11 +190,22 @@ export class OCREngine {
    * Perform layout analysis and text recognition on the current image, if
    * not already done, and return the page text as a string.
    *
+   * A text recognition model must be loaded with {@link loadModel} before this
+   * is called.
+   *
    * @return {string}
    */
   getText() {
     this._checkImageLoaded();
+    this._checkModelLoaded();
+
     return this._engine.getText();
+  }
+
+  _checkModelLoaded() {
+    if (!this._modelLoaded) {
+      throw new Error("No text recognition model loaded");
+    }
   }
 
   _checkImageLoaded() {

--- a/test/ocr-engine-test.js
+++ b/test/ocr-engine-test.js
@@ -70,16 +70,9 @@ describe("OCREngine", () => {
     });
   });
 
-  it("throws an error if image is loaded before model", async function () {
-    this.timeout(10_000);
-    const ocr = await createEngine({ loadModel: false });
-    const imageData = await loadImage(resolve("./test-page.jpg"));
-    assert.throws(() => {
-      ocr.loadImage(imageData);
-    }, "Model must be loaded before image");
-  });
-
   it("throws an error if OCR is attempted before image is loaded", async () => {
+    const ocr = await createEngine();
+
     assert.throws(() => {
       ocr.getBoundingBoxes();
     }, "No image loaded");
@@ -87,6 +80,24 @@ describe("OCREngine", () => {
     assert.throws(() => {
       ocr.getTextBoxes();
     }, "No image loaded");
+
+    assert.throws(() => {
+      ocr.getText();
+    }, "No image loaded");
+  });
+
+  it("throws an error if OCR is attempted before model is loaded", async () => {
+    const ocr = await createEngine({ loadModel: false });
+    const imageData = await loadImage(resolve("./small-test-page.jpg"));
+    ocr.loadImage(imageData);
+
+    assert.throws(() => {
+      ocr.getTextBoxes();
+    }, "No text recognition model loaded");
+
+    assert.throws(() => {
+      ocr.getText();
+    }, "No text recognition model loaded");
   });
 
   it("extracts bounding boxes from image", async function () {
@@ -121,6 +132,16 @@ describe("OCREngine", () => {
 
     const lineBoxes = ocr.getBoundingBoxes("line");
     assert.equal(lineBoxes.length, 10);
+  });
+
+  it("can extract bounding boxes without a model loaded", async function () {
+    const ocr = await createEngine({ loadModel: false });
+
+    const imageData = await loadImage(resolve("./small-test-page.jpg"));
+    ocr.loadImage(imageData);
+
+    const wordBoxes = ocr.getBoundingBoxes("word");
+    assert.equal(wordBoxes.length, 153);
   });
 
   it("extracts text boxes from image", async function () {


### PR DESCRIPTION
For use cases where only the locations of words/lines are needed, this
potentially allows results to be displayed faster.