### PR TITLE
Support recognition progress callbacks in OCRClient

### DIFF
--- a/src/node-worker.js
+++ b/src/node-worker.js
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { Worker, isMainThread, parentPort } from "node:worker_threads";
 
-import { expose, proxy, wrap } from "comlink";
+import { expose, proxy } from "comlink";
 
 // @ts-ignore
 import nodeEndpoint from "comlink/dist/esm/node-adapter.mjs";
@@ -18,18 +18,9 @@ export function resolve(path, moduleURL = import.meta.url) {
   return fileURLToPath(new URL(path, moduleURL).href);
 }
 
-/**
- * @param {string|URL} url
- */
-function initNodeWorker(url) {
-  const worker = new Worker(new URL(url));
-  const remote = wrap(nodeEndpoint(worker));
-  return { remote, terminate: () => worker.terminate() };
-}
-
 export function createOCRClient(options = {}) {
   return new OCRClient({
-    initWorker: initNodeWorker,
+    createWorker: (url) => new Worker(new URL(url)),
     workerURL: new URL(import.meta.url).href,
     ...options,
   });

--- a/src/ocr-client.js
+++ b/src/ocr-client.js
@@ -1,5 +1,11 @@
 import * as comlink from "comlink";
 
+// Although this import is Node-specific, it is tiny and doesn't import any
+// Node libs, so can be included in a bundle that runs in non-Node environments.
+//
+// @ts-ignore
+import nodeEndpoint from "comlink/dist/esm/node-adapter.mjs";
+
 /**
  * @typedef {import('./ocr-engine').BoxItem} BoxItem
  * @typedef {import('./ocr-engine').TextItem} TextItem
@@ -13,51 +19,71 @@ function defaultWorkerURL() {
 /**
  * @param {string} url
  */
-function initWebWorker(url) {
-  const worker = new Worker(url);
-  const remote = comlink.wrap(worker);
-  return { remote, terminate: () => worker.terminate };
+function createWebWorker(url) {
+  return new Worker(url);
 }
 
 /**
- * @typedef OCRClientWorker
- * @prop {import('comlink').Remote<any>} remote
- * @prop {() => void} terminate
+ * Create a channel to receive progress updates from a Worker and relay them
+ * to a callback.
+ *
+ * This channel is used rather than comlink's recommended approach to callbacks
+ * (see https://github.com/GoogleChromeLabs/comlink#callbacks) because that is
+ * prone to triggering warnings in Node about too many event listeners being
+ * added to a MessagePort, due to the way comlink internally adds and removes
+ * listeners when the proxied callback is invoked.
+ *
+ * @param {(progress: number) => void} onProgress
  */
+function createProgressChannel(onProgress) {
+  const { port1, port2 } = new MessageChannel();
+  port1.onmessage = (event) => {
+    const { progress } = event.data;
+    onProgress(progress);
+  };
+  return comlink.transfer(port2, [port2]);
+}
 
 /**
  * High-level async API for performing OCR.
+ *
+ * In the browser, this class can be constructed directly. In Node, use the
+ * `createOCRClient` helper from `node-worker.js`.
  */
 export class OCRClient {
   /**
    * Initialize an OCR engine.
    *
-   * This will start a Web Worker in which the OCR operations will actually
-   * be performed.
+   * This will start a Worker in which the OCR operations will actually be
+   * performed.
    *
    * @param {object} options
-   *   @param {(url: string) => OCRClientWorker} [options.initWorker] - Internal
-   *     callback that initializes a worker in the current environment. The
-   *     default implementation sets up a Web Worker.
+   *   @param {(url: string) => Worker} [options.createWorker] - Callback that
+   *     creates the worker. The default implementation creates a Web Worker.
    *   @param {Uint8Array|ArrayBuffer} [options.wasmBinary] - WebAssembly binary
    *     to load in worker. If not set, it is loaded from the default location
-   *     relative to the currnet script.
+   *     relative to the current script.
    *   @param {string} [options.workerURL] - Location of worker script/module.
    *     If not set, it is loaded from the default location relative to the
    *     current script.
    */
   constructor({
-    initWorker = initWebWorker,
+    createWorker = createWebWorker,
     wasmBinary,
     workerURL = defaultWorkerURL(),
   } = {}) {
-    const { remote, terminate } = initWorker(workerURL);
-    this._terminate = terminate;
+    const worker = createWorker(workerURL);
+    this._worker = worker;
+
+    const endpoint =
+      "addEventListener" in worker ? worker : nodeEndpoint(worker);
+    const remote = comlink.wrap(endpoint);
+
     this._ocrEngine = remote.createOCREngine({ wasmBinary });
   }
 
   async destroy() {
-    this._terminate();
+    this._worker.terminate();
   }
 
   /**
@@ -124,21 +150,33 @@ export class OCRClient {
    * unit of text.
    *
    * @param {TextUnit} unit
+   * @param {(progress: number) => void} [onProgress]
    * @return {Promise<TextItem[]>}
    */
-  async getTextBoxes(unit) {
+  async getTextBoxes(unit, onProgress) {
     const engine = await this._ocrEngine;
-    return engine.getTextBoxes(unit);
+    const progressChannel = onProgress
+      ? createProgressChannel(onProgress)
+      : undefined;
+    const result = await engine.getTextBoxes(unit, progressChannel);
+    progressChannel?.close();
+    return result;
   }
 
   /**
    * Perform layout analysis and text recognition on the current image, if
    * not already done, and return the image's text as a string.
    *
+   * @param {(progress: number) => void} [onProgress]
    * @return {Promise<string>}
    */
-  async getText() {
+  async getText(onProgress) {
     const engine = await this._ocrEngine;
-    return engine.getText();
+    const progressChannel = onProgress
+      ? createProgressChannel(onProgress)
+      : undefined;
+    const result = await engine.getText(progressChannel);
+    progressChannel?.close();
+    return result;
   }
 }

--- a/test/ocr-client-test.js
+++ b/test/ocr-client-test.js
@@ -87,4 +87,25 @@ describe("OCRClient", () => {
       assert.include(text, phrase);
     }
   });
+
+  it("reports recognition progress", async function () {
+    this.timeout(5_000);
+
+    const imageData = await loadImage(resolve("./small-test-page.jpg"));
+    await ocr.loadImage(imageData);
+
+    const progressSteps = [];
+    const text = await ocr.getText((progress) => {
+      progressSteps.push(progress);
+    });
+
+    assert.isAbove(progressSteps.length, 0);
+    for (let [i, progress] in progressSteps.entries()) {
+      assert.isAboveOrEqual(progess, 0);
+      assert.isBelowOrEqual(progress, 100);
+      if (i > 0) {
+        assert.isAbove(progress, progressSteps[i - 1]);
+      }
+    }
+  });
 });


### PR DESCRIPTION
Initially I tried to use the recommended approach to callbacks with comlink[1].
That ran into an issue with different instances of comlink being used in the
compiled dist/lib.js library and src/node-worker.js, which was fixed by moving
the `comlink.wrap` call into OCRClient. I then ran into an issue with the
proxied callback triggering a warning from Node in the worker thread
(`MaxListenersExceededWarning`). This happened because of the way that the
proxied callback on the worker side adds an event listener on each call, and
then only removes the listener after the callback response is received. If the
callback is invoked many times during the same event loop turn (or just before
the main thread has had a chance to respond) then the listeners accumulate and
in this case can easily hit Node's default warning limit of 10. To work around
that, `comlink.proxy(callback)` was replaced by creating a direct MessageChannel
ourselves for progress communication.

[1] https://github.com/GoogleChromeLabs/comlink#callbacks

