### PR TITLE
Export `supportsFastBuild` helper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export { OCRClient } from "./ocr-client";
-export { createOCREngine, layoutFlags } from "./ocr-engine";
+export { createOCREngine, layoutFlags, supportsFastBuild } from "./ocr-engine";

--- a/src/ocr-client.js
+++ b/src/ocr-client.js
@@ -26,7 +26,8 @@ function createWebWorker(url) {
 /** @typedef {(progress: number) => void} ProgressListener */
 
 /**
- * High-level async API for performing OCR.
+ * High-level async API for performing document image layout analysis and
+ * OCR.
  *
  * In the browser, this class can be constructed directly. In Node, use the
  * `createOCRClient` helper from `node-worker.js`.

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -278,15 +278,27 @@ function resolve(path, baseURL) {
 }
 
 /**
+ * Return true if the current JS runtime supports all the WebAssembly features
+ * needed for the "fast" WebAssembly build. If not, the "fallback" version must
+ * be used.
+ */
+export function supportsFastBuild() {
+  return wasmSIMDSupported();
+}
+
+/**
  * Initialize the OCR library and return a new {@link OCREngine}.
  *
  * @param {object} options
- *   @param {Uint8Array|ArrayBuffer} [options.wasmBinary]
+ *   @param {Uint8Array|ArrayBuffer} [options.wasmBinary] - WebAssembly binary
+ *     to load. This can be used to customize how the binary URL is determined
+ *     and fetched. {@link supportsFastBuild} can be used to determine which
+ *     build to load.
  *   @param {MessagePort} [options.progressChannel]
  */
 export async function createOCREngine({ wasmBinary, progressChannel } = {}) {
   if (!wasmBinary) {
-    const wasmPath = wasmSIMDSupported()
+    const wasmPath = supportsFastBuild()
       ? "./tesseract-core.wasm"
       : "./tesseract-core-fallback.wasm";
 

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -58,12 +58,16 @@ export const layoutFlags = {
  */
 
 /**
+ * Item of text found in a document image by layout analysis.
+ *
  * @typedef BoxItem
  * @prop {IntRect} rect
  * @prop {number} flags - Combination of flags from {@link layoutFlags}
  */
 
 /**
+ * Item of text found in a document image by layout analysis and OCR.
+ *
  * @typedef TextItem
  * @prop {IntRect} rect
  * @prop {number} flags - Combination of flags from {@link layoutFlags}
@@ -254,6 +258,7 @@ class OCREngine {
     }
   }
 }
+
 function wasmSIMDSupported() {
   // Tiny WebAssembly file generated from the following source using `wat2wasm`:
   //

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -84,11 +84,13 @@ export const layoutFlags = {
 /**
  * Low-level synchronous API for performing OCR.
  *
+ * Instances are constructed using {@link createOCREngine}.
  */
-export class OCREngine {
+class OCREngine {
   /**
-   * @param {any} tessLib
-   * @param {MessagePort} [progressChannel]
+   * @param {any} tessLib - Emscripten entry point for the compiled WebAssembly module.
+   * @param {MessagePort} [progressChannel] - Channel used to report progress
+   *   updates when OCREngine is run on a background thread
    */
   constructor(tessLib, progressChannel) {
     this._tesseractLib = tessLib;

--- a/test/ocr-engine-test.js
+++ b/test/ocr-engine-test.js
@@ -3,7 +3,11 @@ import { readFile } from "node:fs/promises";
 
 import { assert } from "chai";
 
-import { createOCREngine, layoutFlags } from "../dist/lib.js";
+import {
+  createOCREngine,
+  layoutFlags,
+  supportsFastBuild,
+} from "../dist/lib.js";
 import { loadImage, resolve } from "./util.js";
 
 const { StartOfLine, EndOfLine } = layoutFlags;
@@ -38,6 +42,12 @@ function emptyImage(width = 100, height = 100) {
     height,
   };
 }
+
+describe("supportsFastBuild", () => {
+  it("returns true in a modern Node engine", () => {
+    assert.isTrue(supportsFastBuild());
+  });
+});
 
 describe("OCREngine", () => {
   let ocr;


### PR DESCRIPTION
Add a `supportsFastBuild` helper for consumers who are handling loading of the WASM library themselves. Also un-export the `OCREngine` constructor to avoid confusion over how to instantiate it - the `createOCREngine` function must always be used.