### PR TITLE
Simplify web demo setup

### DIFF
--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -2,15 +2,11 @@
 
 ## How to run
 
-1. Download the English language text recognition model
-
-   ```sh
-   curl -L 'https://github.com/tesseract-ocr/tessdata_fast/raw/main/eng.traineddata' -o eng.traineddata
-   ```
-2. Install packages and build/serve demo
+1. Install packages and start server
 
    ```sh
    npm install
    npm run serve
    ```
-3. Open http://127.0.0.1:8000/ in your browser
+
+2. Open http://127.0.0.1:8000/ in your browser

--- a/examples/web/ocr-app.js
+++ b/examples/web/ocr-app.js
@@ -130,7 +130,12 @@ function OCRDemoApp() {
           workerURL: "node_modules/tesseract-wasm/dist/tesseract-worker.js",
         });
 
-        await ocrClient.current.loadModel("./eng.traineddata");
+        // Fetch OCR model. In production you would probably want to serve this
+        // yourself and ensure that the model is well compressed (eg.  using
+        // Brotli) to reduce the download size and cached for a long time.
+        await ocrClient.current.loadModel(
+          "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/main/eng.traineddata"
+        );
       }
       const ocr = ocrClient.current;
 

--- a/examples/web/ocr-app.js
+++ b/examples/web/ocr-app.js
@@ -100,6 +100,7 @@ function OCRDemoApp() {
   const [documentText, setDocumentText] = useState(null);
   const [error, setError] = useState(null);
   const [ocrProgress, setOCRProgress] = useState(null);
+  const [status, setStatus] = useState(null);
   const [wordBoxes, setWordBoxes] = useState([]);
 
   const canvasRef = useRef(null);
@@ -123,6 +124,7 @@ function OCRDemoApp() {
       if (!ocrClient.current) {
         // Initialize the OCR engine when recognition is performed for the first
         // time.
+        setStatus("Initializing OCR engine");
         ocrClient.current = new OCRClient({
           // In a production application, you would serve the tesseract-worker.js
           // and .wasm files from node_modules/tesseract-wasm/dist/ alongside
@@ -140,9 +142,11 @@ function OCRDemoApp() {
       const ocr = ocrClient.current;
 
       try {
+        setStatus("Loading image");
         await ocr.loadImage(documentImage);
 
         // Perform OCR and display progress.
+        setStatus("Recognizing text");
         let boxes = await ocr.getTextBoxes("word", setOCRProgress);
         boxes = boxes.filter((box) => box.text.trim() !== "");
         setWordBoxes(boxes);
@@ -155,6 +159,7 @@ function OCRDemoApp() {
         setError(err);
       } finally {
         setOCRProgress(null);
+        setStatus(null);
       }
     };
     doOCR();
@@ -178,6 +183,7 @@ function OCRDemoApp() {
         </div>
       )}
       <FileDropZone onDrop={loadImage} />
+      {status !== null && <div>{status}…</div>}
       {ocrProgress !== null && <ProgressBar value={ocrProgress} />}
       {documentImage && (
         <div className="OCRDemoApp__output">

--- a/examples/web/ocr-app.js
+++ b/examples/web/ocr-app.js
@@ -129,6 +129,9 @@ function OCRDemoApp() {
           // In a production application, you would serve the tesseract-worker.js
           // and .wasm files from node_modules/tesseract-wasm/dist/ alongside
           // your JS bundle, and setting `workerURL` would not be required.
+          //
+          // Note that the worker must be served from the same origin as your
+          // application.
           workerURL: "node_modules/tesseract-wasm/dist/tesseract-worker.js",
         });
 


### PR DESCRIPTION
Simplify the setup of the web demo by loading the trained model from GitHub directly. I also added some more status information so the user can see something happening while the model is being fetched.