### PR TITLE
Pass image data to Tesseract as a Leptonica image

### DIFF
--- a/test/ocr-engine-test.js
+++ b/test/ocr-engine-test.js
@@ -62,21 +62,25 @@ describe("OCREngine", () => {
 
   [
     // Image size does not match buffer size
-    {
-      data: new ArrayBuffer(10),
-      width: 100,
-      height: 100,
-    },
+    [
+      {
+        data: new Uint8ClampedArray(10),
+        width: 100,
+        height: 100,
+      },
+      "Image data length does not match width/height",
+    ],
+
     // Zero width image
-    emptyImage(0, 100),
+    [emptyImage(0, 100), "Image width or height is zero"],
 
     // Zero height image
-    emptyImage(100, 0),
-  ].forEach((imageData) => {
+    [emptyImage(100, 0), "Image width or height is zero"],
+  ].forEach(([imageData, expectedError]) => {
     it("throws an error if image fails to load", () => {
       assert.throws(() => {
         ocr.loadImage(imageData);
-      }, "Failed to load image");
+      }, expectedError);
     });
   });
 


### PR DESCRIPTION
Reduce the number of copies of image data by creating a Leptonica image
and copying bytes from the ImageData object to the Leptonica buffer via
typed array APIs. This avoids an extra internal copy that Tesseract does
when a buffer pointer + length is passed to `TessBaseAPI::SetImage`. In
total I believe the image data is now copied twice:

 1. ImageData => Leptonica PIX* buffer
 2. TessBaseAPI::SetImage copies the input image

Tesseract operates on PIX* buffers internally, so potentially the second
copy could be avoided with changes to Tesseract.

Reducing copies is more efficient, and also reduces the peak memory usage,
allowing larger images to be processed given the same max memory allowance for
the WASM memory.