### PR TITLE
Free previous image before loading new one

### DIFF
--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -155,6 +155,8 @@ class OCREngine {
     return {};
   }
 
+  void ClearImage() { tesseract_->Clear(); }
+
   std::vector<TextRect> GetBoundingBoxes(TextUnit unit) {
     if (!layout_analysis_done_) {
       tesseract_->AnalyseLayout();
@@ -244,6 +246,7 @@ EMSCRIPTEN_BINDINGS(ocrlib) {
 
   class_<OCREngine>("OCREngine")
       .constructor<>()
+      .function("clearImage", &OCREngine::ClearImage)
       .function("loadModel", &OCREngine::LoadModel)
       .function("loadImage", &OCREngine::LoadImage)
       .function("getBoundingBoxes", &OCREngine::GetBoundingBoxes)

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -151,6 +151,10 @@ class OCREngine {
       throw new Error("Image width or height is zero");
     }
 
+    // Free up resources used by the previous image, if any. Doing this before
+    // creating the buffer for the new image reduces peak memory usage.
+    this._engine.clearImage();
+
     // Allocate a temporary internal image for transfering the image data into
     // Tesseract
     const engineImage = new this._tesseractLib.Image(


### PR DESCRIPTION
Ask Tesseract to free its copy of the previous image before loading a new one.
This reduces the peak memory usage of the WASM module and reduces the
probability of hitting the current 128MB cap with large images.

When testing with a 2421x3307 scan of a document page in the web demo app for
example, recognition would succeed when the image was first loaded, but would
fail if you tried to load it a second time. Now the image can be reloaded
repeatedly.

This will help with https://github.com/robertknight/tesseract-wasm/issues/31