### PR TITLE
Add simple orientation detection

### DIFF
--- a/examples/web/ocr-app.js
+++ b/examples/web/ocr-app.js
@@ -104,6 +104,7 @@ function OCRDemoApp() {
   const [ocrProgress, setOCRProgress] = useState(null);
   const [status, setStatus] = useState(null);
   const [wordBoxes, setWordBoxes] = useState([]);
+  const [orientation, setOrientation] = useState(null);
 
   const canvasRef = useRef(null);
 
@@ -114,6 +115,7 @@ function OCRDemoApp() {
 
     setError(null);
     setWordBoxes(null);
+    setOrientation(null);
 
     // Set progress to `0` rather than `null` here to show the progress bar
     // immediately after an image is selected.
@@ -153,6 +155,9 @@ function OCRDemoApp() {
       try {
         setStatus("Loading image");
         await ocr.loadImage(documentImage);
+
+        const orientation = await ocr.getOrientation();
+        setOrientation(orientation);
 
         // Perform OCR and display progress.
         setStatus("Recognizing text");
@@ -227,6 +232,9 @@ function OCRDemoApp() {
       <FileDropZone onDrop={loadImage} />
       {status !== null && <div>{status}…</div>}
       {ocrProgress !== null && <ProgressBar value={ocrProgress} />}
+      {orientation !== null &&
+        orientation !== 0 &&
+        `Orientation: ${orientation}°`}
       {documentImage && (
         <div className="OCRDemoApp__output">
           <canvas

--- a/examples/web/ocr-app.js
+++ b/examples/web/ocr-app.js
@@ -96,6 +96,17 @@ function OCRWordBox({ box, imageWidth, imageHeight }) {
   );
 }
 
+function isNormalOrientation(orientation) {
+  return orientation.confidence > 0 && orientation.rotation === 0;
+}
+
+function formatOrientation(orientation) {
+  if (orientation.confidence === 0) {
+    return "Unknown";
+  }
+  return `${orientation.rotation}°`;
+}
+
 function OCRDemoApp() {
   const ocrClient = useRef(null);
   const [documentImage, setDocumentImage] = useState(null);
@@ -233,8 +244,8 @@ function OCRDemoApp() {
       {status !== null && <div>{status}…</div>}
       {ocrProgress !== null && <ProgressBar value={ocrProgress} />}
       {orientation !== null &&
-        orientation !== 0 &&
-        `Orientation: ${orientation}°`}
+        !isNormalOrientation(orientation) &&
+        `Orientation: ${formatOrientation(orientation)}`}
       {documentImage && (
         <div className="OCRDemoApp__output">
           <canvas

--- a/src/ocr-client.js
+++ b/src/ocr-client.js
@@ -10,6 +10,7 @@ import { imageDataFromBitmap } from "./utils";
 
 /**
  * @typedef {import('./ocr-engine').BoxItem} BoxItem
+ * @typedef {import('./ocr-engine').Orientation} Orientation
  * @typedef {import('./ocr-engine').TextItem} TextItem
  * @typedef {import('./ocr-engine').TextUnit} TextUnit
  */
@@ -203,6 +204,11 @@ export class OCRClient {
     }
   }
 
+  /**
+   * Attempt to determine the orientation of the image.
+   *
+   * @return {Promise<Orientation>}
+   */
   async getOrientation() {
     const engine = await this._ocrEngine;
     return engine.getOrientation();

--- a/src/ocr-client.js
+++ b/src/ocr-client.js
@@ -203,6 +203,11 @@ export class OCRClient {
     }
   }
 
+  async getOrientation() {
+    const engine = await this._ocrEngine;
+    return engine.getOrientation();
+  }
+
   /** @param {ProgressListener} listener */
   _addProgressListener(listener) {
     this._progressListeners.push(listener);

--- a/src/ocr-client.js
+++ b/src/ocr-client.js
@@ -207,6 +207,12 @@ export class OCRClient {
   /**
    * Attempt to determine the orientation of the image.
    *
+   * This currently uses a simplistic algorithm [1] which is designed for
+   * non-uppercase Latin text. It will likely perform badly for other scripts or
+   * if the text is all uppercase.
+   *
+   * [1] See http://www.leptonica.org/papers/skew-measurement.pdf
+   *
    * @return {Promise<Orientation>}
    */
   async getOrientation() {

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -66,6 +66,14 @@ export const layoutFlags = {
  */
 
 /**
+ * Result of orientation detection.
+ *
+ * @typedef Orientation
+ * @prop {number} rotation
+ * @prop {number} confidence - Confidence value in [0, 1]
+ */
+
+/**
  * @typedef {'line'|'word'} TextUnit
  */
 
@@ -244,9 +252,7 @@ class OCREngine {
   /**
    * Attempt to determine the orientation of the document image in degrees.
    *
-   * Returns 0, 90, 180 or 270.
-   *
-   * @return {number}
+   * @return {Orientation}
    */
   getOrientation() {
     this._checkImageLoaded();

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -252,6 +252,12 @@ class OCREngine {
   /**
    * Attempt to determine the orientation of the document image in degrees.
    *
+   * This currently uses a simplistic algorithm [1] which is designed for
+   * non-uppercase Latin text. It will likely perform badly for other scripts or
+   * if the text is all uppercase.
+   *
+   * [1] See http://www.leptonica.org/papers/skew-measurement.pdf
+   *
    * @return {Orientation}
    */
   getOrientation() {

--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -241,6 +241,18 @@ class OCREngine {
     );
   }
 
+  /**
+   * Attempt to determine the orientation of the document image in degrees.
+   *
+   * Returns 0, 90, 180 or 270.
+   *
+   * @return {number}
+   */
+  getOrientation() {
+    this._checkImageLoaded();
+    return this._engine.getOrientation();
+  }
+
   _checkModelLoaded() {
     if (!this._modelLoaded) {
       throw new Error("No text recognition model loaded");

--- a/test/ocr-client-test.js
+++ b/test/ocr-client-test.js
@@ -108,4 +108,13 @@ describe("OCRClient", () => {
       }
     }
   });
+
+  // Test orientation detection method returns a result. Detailed tests for
+  // different orientations are handled in the OCREngine tests.
+  it("can determine image orientation", async () => {
+    const imageData = await loadImage(resolve("./small-test-page.jpg"));
+    await ocr.loadImage(imageData);
+    const orientation = await ocr.getOrientation();
+    assert.equal(orientation, 0);
+  });
 });

--- a/test/ocr-client-test.js
+++ b/test/ocr-client-test.js
@@ -114,7 +114,8 @@ describe("OCRClient", () => {
   it("can determine image orientation", async () => {
     const imageData = await loadImage(resolve("./small-test-page.jpg"));
     await ocr.loadImage(imageData);
-    const orientation = await ocr.getOrientation();
-    assert.equal(orientation, 0);
+    const orient = await ocr.getOrientation();
+    assert.equal(orient.rotation, 0);
+    assert.equal(orient.confidence, 1.0);
   });
 });

--- a/test/ocr-engine-test.js
+++ b/test/ocr-engine-test.js
@@ -2,13 +2,14 @@ import { dirname } from "node:path";
 import { readFile } from "node:fs/promises";
 
 import { assert } from "chai";
+import sharp from "sharp";
 
 import {
   createOCREngine,
   layoutFlags,
   supportsFastBuild,
 } from "../dist/lib.js";
-import { loadImage, resolve } from "./util.js";
+import { loadImage, resolve, toImageData } from "./util.js";
 
 const { StartOfLine, EndOfLine } = layoutFlags;
 
@@ -292,5 +293,18 @@ describe("OCREngine", () => {
       progressSteps.push(progress);
     });
     assert.deepEqual(progressSteps, [100]);
+  });
+
+  it("can determine image orientation", async () => {
+    const imagePath = resolve("./small-test-page.jpg");
+
+    for (let orient of [0, 90, 180, 270]) {
+      const image = await sharp(imagePath).ensureAlpha().rotate(orient);
+
+      ocr.loadImage(await toImageData(image));
+      const estimatedOrient = ocr.getOrientation();
+
+      assert.equal(estimatedOrient, orient);
+    }
   });
 });

--- a/test/ocr-engine-test.js
+++ b/test/ocr-engine-test.js
@@ -298,13 +298,14 @@ describe("OCREngine", () => {
   it("can determine image orientation", async () => {
     const imagePath = resolve("./small-test-page.jpg");
 
-    for (let orient of [0, 90, 180, 270]) {
-      const image = await sharp(imagePath).ensureAlpha().rotate(orient);
+    for (let rotation of [0, 90, 180, 270]) {
+      const image = await sharp(imagePath).ensureAlpha().rotate(rotation);
 
       ocr.loadImage(await toImageData(image));
       const estimatedOrient = ocr.getOrientation();
 
-      assert.equal(estimatedOrient, orient);
+      assert.equal(estimatedOrient.rotation, rotation);
+      assert.equal(estimatedOrient.confidence, 1);
     }
   });
 });

--- a/test/util.js
+++ b/test/util.js
@@ -12,14 +12,25 @@ export function resolve(path, moduleURL = import.meta.url) {
 }
 
 /**
- * @param {string} path
+ * Convert a sharp image to an ImageData-like object that can be passed to
+ * OCREngine and OCRClient.
  */
-export async function loadImage(path) {
-  const image = await sharp(path).ensureAlpha();
+export async function toImageData(image) {
   const { width, height } = await image.metadata();
   return {
     data: await image.raw().toBuffer(),
     width,
     height,
   };
+}
+
+/**
+ * Load and decode an image into an ImageData-like object.
+ *
+ * @param {string} path
+ * @return {ImageData}
+ */
+export async function loadImage(path) {
+  const image = await sharp(path).ensureAlpha();
+  return toImageData(image);
 }


### PR DESCRIPTION
Add simple orientation detection using Leptonica's `pixOrientDetect` function. This was used in Tesseract because Tesseract's implementation requires the legacy (non-LSTM) engine, which is not compiled in. Leptonica's algorithm relies mostly on "the preponderence of ascenders over descenders in languages with roman characters", per [this paper](http://www.leptonica.org/papers/skew-measurement.pdf). Tesseract's approach which is not being used [is described here](https://tesseract-ocr.github.io/docs/Combined_Orientation_and_Script_Detection_using_the_Tesseract_OCR_Engine.pdf).

**TODO:**

- [x] Investigate issues with same rotated image producing different results when loaded in different browsers (see notes in second commit)
- [x] Perhaps add a way for `getOrientation` API to indicate uncertainty in the result or errors in the process. Currently it returns 0 in the event of any error, and has no way to represent confidence in the result.