### PR TITLE
Convert ImageBitmap => ImageData on the main thread in all browsers

### DIFF
--- a/src/ocr-engine.js
+++ b/src/ocr-engine.js
@@ -1,6 +1,8 @@
 // @ts-ignore - Don't error if library hasn't been built yet.
 import initTesseractCore from "../build/tesseract-core";
 
+import { imageDataFromBitmap } from "./utils";
+
 /**
  * JS interface to a `std::vector` returned from a C++ method wrapped by
  * Embind.
@@ -10,18 +12,6 @@ import initTesseractCore from "../build/tesseract-core";
  * @prop {() => number} size
  * @prop {(index: number) => T} get
  */
-
-/**
- * @param {ImageBitmap} bitmap
- */
-function imageDataFromBitmap(bitmap) {
-  // @ts-expect-error - OffscreenCanvas API is missing
-  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
-  /** @type {CanvasRenderingContext2D} */
-  const context = canvas.getContext("2d");
-  context.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
-  return context.getImageData(0, 0, bitmap.width, bitmap.height);
-}
 
 /**
  * Create a JS array from a std::vector wrapper created by Embind.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,26 @@
+/**
+ * @param {ImageBitmap} bitmap
+ * @return {ImageData}
+ */
+export function imageDataFromBitmap(bitmap) {
+  /** @type {HTMLCanvasElement} */
+  let canvas;
+  // @ts-expect-error - OffscreenCanvas API is missing
+  if (typeof OffscreenCanvas !== "undefined") {
+    // @ts-expect-error - OffscreenCanvas API is missing
+    canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  } else if (typeof HTMLCanvasElement !== "undefined") {
+    const canvasEl = document.createElement("canvas");
+    canvasEl.width = bitmap.width;
+    canvasEl.height = bitmap.height;
+    canvas = canvasEl;
+  } else {
+    throw new Error("No canvas implementation available");
+  }
+
+  const context = /** @type {CanvasRenderingContext2D} */ (
+    canvas.getContext("2d")
+  );
+  context.drawImage(bitmap, 0, 0, bitmap.width, bitmap.height);
+  return context.getImageData(0, 0, bitmap.width, bitmap.height);
+}


### PR DESCRIPTION
Chrome has a bug where image orientation metadata in JPEG images is lost
when an ImageBitmap is cloned via a structured clone [1]. Therefore we have
to do ImageBitmap => ImageData conversion on the main thread to ensure
that the OCR engine receives decoded image data which respects the image
orientation.

Prior to this fix the rendered image orientation and the OCR output did
not match up in Chrome if the input image was rotated.

Since neither Firefox nor Safari support OffscreenCanvas, this means
that all browsers are now doing ImageBitmap => ImageData conversion on
the main thread.

Fixes #35

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=1332947