### PR TITLE
Ensure all types used in public APIs are exported, add command to build API docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ checkformat:
 typecheck:
 	node_modules/.bin/tsc
 
+.PHONY: api-docs
+api-docs:
+	node_modules/.bin/typedoc --excludePrivate --out docs/api/ src/index.ts
+
 .PHONY: test
 test: third_party/tessdata_fast
 	node_modules/.bin/mocha

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "prettier": "^2.6.2",
         "rollup": "^2.73.0",
         "sharp": "^0.30.4",
+        "typedoc": "^0.22.17",
         "typescript": "^4.6.4"
       }
     },
@@ -1092,6 +1093,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1144,6 +1151,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -1151,6 +1164,18 @@
       "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+      "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/mimic-response": {
@@ -1669,6 +1694,17 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -1888,6 +1924,68 @@
         "node": ">=4"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.22.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.17.tgz",
+      "integrity": "sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
@@ -1905,6 +2003,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "node_modules/wide-align": {
@@ -2900,6 +3010,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2937,6 +3053,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -2945,6 +3067,12 @@
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "marked": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+      "integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
+      "dev": true
     },
     "mimic-response": {
       "version": "3.1.0",
@@ -3336,6 +3464,17 @@
         "tunnel-agent": "^0.6.0"
       }
     },
+    "shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -3493,6 +3632,52 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "typedoc": {
+      "version": "0.22.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.17.tgz",
+      "integrity": "sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==",
+      "dev": true,
+      "requires": {
+        "glob": "^8.0.3",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
@@ -3503,6 +3688,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "wide-align": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prettier": "^2.6.2",
     "rollup": "^2.73.0",
     "sharp": "^0.30.4",
+    "typedoc": "^0.22.17",
     "typescript": "^4.6.4"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,16 @@
 export { OCRClient } from "./ocr-client";
+
+export type { OCRClientInit } from "./ocr-client";
+
 export { createOCREngine, layoutFlags, supportsFastBuild } from "./ocr-engine";
-export type { BoxItem, Orientation, TextItem, TextUnit } from "./ocr-engine";
+
+export type {
+  CreateOCREngineOptions,
+  BoxItem,
+  IntRect,
+  OCREngine,
+  Orientation,
+  ProgressListener,
+  TextItem,
+  TextUnit,
+} from "./ocr-engine";

--- a/src/ocr-client.ts
+++ b/src/ocr-client.ts
@@ -1,6 +1,12 @@
 import * as comlink from "comlink";
 
-import type { BoxItem, Orientation, TextItem, TextUnit } from "./ocr-engine";
+import type {
+  BoxItem,
+  Orientation,
+  ProgressListener,
+  TextItem,
+  TextUnit,
+} from "./ocr-engine";
 
 // Although this import is Node-specific, it is tiny and doesn't import any
 // Node libs, so can be included in a bundle that runs in non-Node environments.
@@ -17,8 +23,6 @@ function defaultWorkerURL() {
 function createWebWorker(url: string) {
   return new Worker(url);
 }
-
-type ProgressListener = (progress: number) => void;
 
 export type OCRClientInit = {
   /**
@@ -213,11 +217,11 @@ export class OCRClient {
     return engine.getOrientation();
   }
 
-  _addProgressListener(listener: ProgressListener) {
+  private _addProgressListener(listener: ProgressListener) {
     this._progressListeners.push(listener);
   }
 
-  _removeProgressListener(listener: ProgressListener) {
+  private _removeProgressListener(listener: ProgressListener) {
     this._progressListeners = this._progressListeners.filter(
       (l) => l !== listener
     );

--- a/src/ocr-engine.ts
+++ b/src/ocr-engine.ts
@@ -81,14 +81,14 @@ export type TextUnit = "line" | "word";
 /**
  * Handler that receives OCR operation progress updates.
  */
-export type ProgressHandler = (progress: number) => void;
+export type ProgressListener = (progress: number) => void;
 
 /**
  * Low-level synchronous API for performing OCR.
  *
  * Instances are constructed using {@link createOCREngine}.
  */
-class OCREngine {
+export class OCREngine {
   private _tesseractLib: any;
   private _engine: any;
   private _modelLoaded: boolean;
@@ -96,6 +96,10 @@ class OCREngine {
   private _progressChannel?: MessagePort;
 
   /**
+   * Initialize the OCREngine.
+   *
+   * Use {@link createOCREngine} rather than calling this directly.
+   *
    * @param tessLib - Emscripten entry point for the compiled WebAssembly module.
    * @param progressChannel - Channel used to report progress
    *   updates when OCREngine is run on a background thread
@@ -204,7 +208,7 @@ class OCREngine {
    * A text recognition model must be loaded with {@link loadModel} before this
    * is called.
    */
-  getTextBoxes(unit: TextUnit, onProgress?: ProgressHandler): TextItem[] {
+  getTextBoxes(unit: TextUnit, onProgress?: ProgressListener): TextItem[] {
     this._checkImageLoaded();
     this._checkModelLoaded();
 
@@ -225,7 +229,7 @@ class OCREngine {
    * A text recognition model must be loaded with {@link loadModel} before this
    * is called.
    */
-  getText(onProgress?: ProgressHandler): string {
+  getText(onProgress?: ProgressListener): string {
     this._checkImageLoaded();
     this._checkModelLoaded();
     return this._engine.getText((progress: number) => {
@@ -248,19 +252,19 @@ class OCREngine {
     return this._engine.getOrientation();
   }
 
-  _checkModelLoaded() {
+  private _checkModelLoaded() {
     if (!this._modelLoaded) {
       throw new Error("No text recognition model loaded");
     }
   }
 
-  _checkImageLoaded() {
+  private _checkImageLoaded() {
     if (!this._imageLoaded) {
       throw new Error("No image loaded");
     }
   }
 
-  _textUnitForUnit(unit: TextUnit) {
+  private _textUnitForUnit(unit: TextUnit) {
     const { TextUnit } = this._tesseractLib;
     switch (unit) {
       case "word":

--- a/update-gh-pages.sh
+++ b/update-gh-pages.sh
@@ -21,6 +21,9 @@ mkdir -p docs/
 cp -R examples/web/index.html examples/web/ocr-app.css examples/web/build docs/
 cp examples/web/node_modules/tesseract-wasm/dist/tesseract-* docs/build/
 
+# Build API docs
+make api-docs
+
 # Commit updated build.
 git add docs
 git commit -m "Update GitHub Pages"


### PR DESCRIPTION
Add a `make api-docs` command to build API docs using typedoc, and fix the warnings it reported about various types used in public APIs not being exported.

Also ensure that private methods are explicitly marked as such.