### PR TITLE
Copy static assets to build dir in web example

### DIFF
--- a/examples/web/copy-static-assets.js
+++ b/examples/web/copy-static-assets.js
@@ -1,0 +1,19 @@
+import { cpSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// List of files which tesseract-wasm expects to be served alongside the JS
+// bundle, if using its default asset location settings.
+const files = [
+  "tesseract-core.wasm", // Main OCR engine module
+  "tesseract-core-fallback.wasm", // Slower version for browsers without SIMD support
+  "tesseract-worker.js", // JS entry point for the web worker
+];
+
+for (let file of files) {
+  const rootDir = dirname(fileURLToPath(import.meta.url));
+  cpSync(
+    `${rootDir}/node_modules/tesseract-wasm/dist/${file}`,
+    `${rootDir}/build/${file}`
+  );
+}

--- a/examples/web/ocr-app.js
+++ b/examples/web/ocr-app.js
@@ -139,19 +139,7 @@ function OCRDemoApp() {
       if (!ocrClient.current) {
         // Initialize the OCR engine when recognition is performed for the first
         // time.
-        const isGitHubPages = location.hostname.endsWith(".github.io");
-        const options = {};
-        if (!isGitHubPages) {
-          // In a production application, you would serve the tesseract-worker.js
-          // and .wasm files from node_modules/tesseract-wasm/dist/ alongside
-          // your JS bundle, and setting `workerURL` would not be required.
-          //
-          // Note that the worker must be served from the same origin as your
-          // application.
-          options.workerURL =
-            "node_modules/tesseract-wasm/dist/tesseract-worker.js";
-        }
-        ocrClient.current = new OCRClient(options);
+        ocrClient.current = new OCRClient();
 
         // Fetch OCR model. In production you would probably want to serve this
         // yourself and ensure that the model is well compressed (eg.  using

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.0",
   "description": "Demo app for tesseract-wasm",
   "main": "ocr-app.js",
+  "type": "module",
   "scripts": {
-    "build": "esbuild ocr-app.js --target=es2020 --format=esm --minify --loader:.js=jsx --bundle --outfile=build/ocr-app.bundle.js",
-    "serve": "esbuild ocr-app.js --target=es2020 --format=esm --loader:.js=jsx --bundle --servedir=. --outfile=build/ocr-app.bundle.js"
+    "build": "node copy-static-assets.js && esbuild ocr-app.js --target=es2020 --format=esm --minify --loader:.js=jsx --bundle --outfile=build/ocr-app.bundle.js",
+    "serve": "node copy-static-assets.js && esbuild ocr-app.js --target=es2020 --format=esm --loader:.js=jsx --bundle --servedir=. --outfile=build/ocr-app.bundle.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This avoids the need to override the default web worker URL when constructing
the OCRClient, and makes the example follow the recommendations for how end
users should serve the WebAssembly module and web worker.