### PR TITLE
use make for typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build examples
       run: make examples
     - name: Typecheck
-      run: npm run-script typecheck
+      run: make typecheck
     - name: Check formatting
       run: make checkformat
     - name: Run tests

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "./node": "./src/node-worker.js"
   },
   "scripts": {
-    "test": "make test",
-    "typecheck": "tsc"
+    "test": "make test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously, there appeared to be two ways to invoke typechecking: the Makefile and npm/package.json. This commit reduces ambiguity by moving CI typechecking to the Makefile, where all the other build steps live.