### PR TITLE
peg github actions runs-on to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous integration
 on: pull_request
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
toward https://github.com/robertknight/tesseract-wasm/issues/63