### PR TITLE
Add option to get output in hOCR format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ EMCC_FLAGS =\
   -sMODULARIZE=1 \
   -sALLOW_MEMORY_GROWTH\
   -sMAXIMUM_MEMORY=128MB \
+  -std=c++20 \
   --post-js=src/tesseract-init.js
 
 # Build main WASM binary for browsers that support WASM SIMD.

--- a/patches/tesseract.diff
+++ b/patches/tesseract.diff
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8c6845cb..5a948117 100644
+index 8c6845cb..fdcfc4a8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -90,6 +90,7 @@ option(ENABLE_LTO "Enable link-time optimization" OFF)
@@ -20,11 +20,10 @@ index 8c6845cb..5a948117 100644
    src/wordrec/*.cpp)
  
  if(DISABLED_LEGACY_ENGINE)
-@@ -713,14 +712,7 @@ file(
- 
+@@ -714,13 +713,7 @@ file(
  set(TESSERACT_SRC
      ${TESSERACT_SRC}
--    src/api/baseapi.cpp
+     src/api/baseapi.cpp
 -    src/api/capi.cpp
 -    src/api/renderer.cpp
 -    src/api/altorenderer.cpp
@@ -32,11 +31,11 @@ index 8c6845cb..5a948117 100644
 -    src/api/lstmboxrenderer.cpp
 -    src/api/pdfrenderer.cpp
 -    src/api/wordstrboxrenderer.cpp)
-+    src/api/baseapi.cpp)
++    src/api/hocrrenderer.cpp)
  
  set(TESSERACT_CONFIGS
    tessdata/configs/alto
-@@ -858,14 +850,16 @@ endif()
+@@ -858,14 +851,16 @@ endif()
  # EXECUTABLE tesseract
  # ##############################################################################
  
@@ -60,7 +59,7 @@ index 8c6845cb..5a948117 100644
  endif()
  
  # ##############################################################################
-@@ -899,7 +893,11 @@ write_basic_package_version_file(
+@@ -899,7 +894,11 @@ write_basic_package_version_file(
  
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tesseract.pc
          DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/src/ocr-client.ts
+++ b/src/ocr-client.ts
@@ -219,6 +219,25 @@ export class OCRClient {
   }
 
   /**
+   * Perform layout analysis and text recognition on the current image, if
+   * not already done, and return the image's text in hOCR format (see
+   * https://en.wikipedia.org/wiki/HOCR).
+   */
+  async getHOCR(onProgress?: ProgressListener): Promise<string> {
+    const engine = await this._ocrEngine;
+    if (onProgress) {
+      this._addProgressListener(onProgress);
+    }
+    try {
+      return await engine.getHOCR();
+    } finally {
+      if (onProgress) {
+        this._removeProgressListener(onProgress);
+      }
+    }
+  }
+
+  /**
    * Attempt to determine the orientation of the image.
    *
    * This currently uses a simplistic algorithm [1] which is designed for

--- a/src/ocr-engine.ts
+++ b/src/ocr-engine.ts
@@ -283,6 +283,22 @@ export class OCREngine {
   }
 
   /**
+   * Perform layout analysis and text recognition on the current image, if
+   * not already done, and return the page text in hOCR format.
+   *
+   * A text recognition model must be loaded with {@link loadModel} before this
+   * is called.
+   */
+  getHOCR(onProgress?: ProgressListener): string {
+    this._checkImageLoaded();
+    this._checkModelLoaded();
+    return this._engine.getHOCR((progress: number) => {
+      onProgress?.(progress);
+      this._progressChannel?.postMessage({ progress });
+    });
+  }
+
+  /**
    * Attempt to determine the orientation of the document image in degrees.
    *
    * This currently uses a simplistic algorithm [1] which is designed for

--- a/test/ocr-client-test.js
+++ b/test/ocr-client-test.js
@@ -88,6 +88,24 @@ describe("OCRClient", () => {
     }
   });
 
+  it("extracts hOCR from image", async function () {
+    this.timeout(5_000);
+
+    const imageData = await loadImage(resolve("./small-test-page.jpg"));
+    await ocr.loadImage(imageData);
+
+    const html = await ocr.getHOCR();
+
+    const expectedPhrases = [
+      "class='ocr_page' id='page_1'",
+      "<span class='ocrx_word' id='word_1_1' title='bbox 37 233 135 265; x_wconf 93'>Image</span>",
+    ];
+
+    for (let phrase of expectedPhrases) {
+      assert.include(html, phrase);
+    }
+  });
+
   it("reports recognition progress", async function () {
     this.timeout(5_000);
 

--- a/test/ocr-engine-test.js
+++ b/test/ocr-engine-test.js
@@ -286,6 +286,24 @@ describe("OCREngine", () => {
     }
   });
 
+  it("extracts hOCR from image", async function () {
+    this.timeout(5_000);
+
+    const imageData = await loadImage(resolve("./small-test-page.jpg"));
+    ocr.loadImage(imageData);
+
+    const html = ocr.getHOCR();
+
+    const expectedPhrases = [
+      "class='ocr_page' id='page_1'",
+      "<span class='ocrx_word' id='word_1_1' title='bbox 37 233 135 265; x_wconf 93'>Image</span>",
+    ];
+
+    for (let phrase of expectedPhrases) {
+      assert.include(html, phrase);
+    }
+  });
+
   it("reports recognition progress", async function () {
     this.timeout(5_000);
 


### PR DESCRIPTION
Add methods to OCRClient and OCREngine to get output in hOCR format, for use with existing OCR tools, and add a dropdown menu in the demo output to allow switching between plain text and hOCR formats.