### PR TITLE
Increase max heap size to 1GB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ EMCC_FLAGS =\
   -sFILESYSTEM=0 \
   -sMODULARIZE=1 \
   -sALLOW_MEMORY_GROWTH\
-  -sMAXIMUM_MEMORY=128MB \
+  -sMAXIMUM_MEMORY=1GB \
   -std=c++20 \
   --post-js=src/tesseract-init.js
 


### PR DESCRIPTION
Very large input images (see #31) can cause the current 128MB limit to be reached.

According to https://github.com/emscripten-core/emscripten/blob/d51b376a7f53ca61ca86a9d2ce4578b629ee625c/src/settings.js#L161 the initial memory defaults to 16MB, and the `ALLOW_MEMORY_GROWTH` setting allows it to grow up to this cap.

Fixes #31