### PR TITLE
Fix missing baseline info and wrong text angle in hOCR output

### DIFF
--- a/patches/tesseract.diff
+++ b/patches/tesseract.diff
@@ -89,6 +89,21 @@ index 1afe5a5d..cb8c6d4c 100644
  
  #if defined(HAS_CPUID)
  #  if defined(__GNUC__)
+diff --git a/src/ccmain/pageiterator.cpp b/src/ccmain/pageiterator.cpp
+index 64ff7f66..c0f80e5f 100644
+--- a/src/ccmain/pageiterator.cpp
++++ b/src/ccmain/pageiterator.cpp
+@@ -582,7 +582,9 @@ void PageIterator::Orientation(tesseract::Orientation *orientation,
+   up_in_image.rotate(block->re_rotation());
+ 
+   if (up_in_image.x() == 0.0F) {
+-    if (up_in_image.y() > 0.0F) {
++    // tesseract-wasm note: `up_in_image` will be a null vector if orientation
++    // info is not available. In that case, assume page up.
++    if (up_in_image.y() >= 0.0F) {
+       *orientation = ORIENTATION_PAGE_UP;
+     } else {
+       *orientation = ORIENTATION_PAGE_DOWN;
 diff --git a/src/ccmain/pagesegmain.cpp b/src/ccmain/pagesegmain.cpp
 index 0af44607..718e73ef 100644
 --- a/src/ccmain/pagesegmain.cpp

--- a/test/ocr-client-test.js
+++ b/test/ocr-client-test.js
@@ -96,9 +96,11 @@ describe("OCRClient", () => {
 
     const html = await ocr.getHOCR();
 
+    // Expected output snippets, covering different kinds of entity (word, line, page).
     const expectedPhrases = [
       "class='ocr_page' id='page_1'",
       "<span class='ocrx_word' id='word_1_1' title='bbox 37 233 135 265; x_wconf 93'>Image</span>",
+      `<span class='ocr_line' id='line_1_5' title="bbox 36 443 1026 462; baseline 0 -5; x_size 18; x_descenders 4; x_ascenders 3">`,
     ];
 
     for (let phrase of expectedPhrases) {

--- a/test/ocr-engine-test.js
+++ b/test/ocr-engine-test.js
@@ -294,9 +294,11 @@ describe("OCREngine", () => {
 
     const html = ocr.getHOCR();
 
+    // Expected output snippets, covering different kinds of entity (word, line, page).
     const expectedPhrases = [
       "class='ocr_page' id='page_1'",
       "<span class='ocrx_word' id='word_1_1' title='bbox 37 233 135 265; x_wconf 93'>Image</span>",
+      `<span class='ocr_line' id='line_1_5' title="bbox 36 443 1026 462; baseline 0 -5; x_size 18; x_descenders 4; x_ascenders 3">`,
     ];
 
     for (let phrase of expectedPhrases) {


### PR DESCRIPTION
hOCR output was missing `baseline` information for `ocr_line` entries and incorrectly reporting every line as being upside-down. This was happening due to https://github.com/tesseract-ocr/tesseract/issues/4010. Work around this issue by handling missing rotation information better in `PageIterator::Orientation`, by assuming the page is facing up.