### PR TITLE
rename emscripten Module to initTesseractCore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ EMCC_FLAGS =\
   -Os\
   --no-entry\
   -sEXPORT_ES6 \
+  -sEXPORT_NAME=initTesseractCore \
   -sENVIRONMENT=web \
   -sFILESYSTEM=0 \
   -sMODULARIZE=1 \


### PR DESCRIPTION
By default, the exported emscripten init function is ambiguously named `Module`. This change ensures it is renamed to `initTesseractCore`, which is consistent with the name used elsewhere in the codebase.