### PR TITLE
emscripten: compile to support both web and worker envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ EMCC_FLAGS =\
   -Os\
   --no-entry\
   -sEXPORT_ES6 \
-  -sENVIRONMENT=web \
+  -sENVIRONMENT=web,worker \
   -sFILESYSTEM=0 \
   -sMODULARIZE=1 \
   -sALLOW_MEMORY_GROWTH\


### PR DESCRIPTION
This is helpful for those browsers, such as Firefox, that don't support Web Worker `type="module"`. The generated module will avoid using `import.meta.url`, for example.

This should resolve the need to rely on Rollup to transform `import.meta.url`.