### PR TITLE
Configure Emscripten to disable dynamic execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ EMCC_FLAGS =\
   -sALLOW_MEMORY_GROWTH\
   -sMAXIMUM_MEMORY=1GB \
   -std=c++20 \
+  -sDYNAMIC_EXECUTION=0 \
   -fexperimental-library \
   --post-js=src/tesseract-init.js
 


### PR DESCRIPTION
The current Emscripten build emits a `new Function(...)` statement, which can cause CSP errors. Setting `DYNAMIC_EXECUTION=0` prevents `eval` and `new Function()` from being emitted.

In my particular case, this was causing an error in a browser extension I'm developing. See also https://stackoverflow.com/questions/64698248/chrome-extension-refused-to-evaluate-a-string-as-javascript-because-unsafe-eval.

@robertknight -- would you be able to publish a new version with this change?

Thanks very much for this great package!!